### PR TITLE
Update GeoSuggestResultItemAddress.cs

### DIFF
--- a/GeoSuggest/GeoSuggestResultItemAddress.cs
+++ b/GeoSuggest/GeoSuggestResultItemAddress.cs
@@ -17,6 +17,6 @@ namespace Yandex.API
     {
         public string Name { get; set; }
 
-        public string Kind { get; set; }
+        public string[] Kind { get; set; }
     }
 }


### PR DESCRIPTION
seems like yandex changed string to array so if you turn address on the current code is not working anymore